### PR TITLE
Implement salary report PDF endpoint

### DIFF
--- a/app/api/salary.py
+++ b/app/api/salary.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Response
 
 from app.schemas.salary import SalaryRow
 from app.services.salary_service import SalaryService
@@ -19,5 +19,16 @@ def create_salary_router(service: SalaryService) -> APIRouter:
     @router.get("/months", response_model=List[str])
     async def list_months():
         return await service.list_months()
+
+    @router.get("/report", response_class=Response)
+    async def salary_report(month: str = Query(...)):
+        rows = await service.get_salary(month=month)
+        from app.services.salary_report import generate_salary_pdf
+
+        pdf_bytes = generate_salary_pdf(rows, month)
+        headers = {"Content-Disposition": "inline; filename=salary_report.pdf"}
+        return Response(content=pdf_bytes,
+                        media_type="application/pdf",
+                        headers=headers)
 
     return router

--- a/app/services/salary_report.py
+++ b/app/services/salary_report.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+from io import BytesIO
+from typing import Iterable
+
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont
+
+from app.schemas.salary import SalaryRow
+from app.config import FONT_PATH
+
+
+def generate_salary_pdf(rows: Iterable[SalaryRow], month: str) -> bytes:
+    """Generate a simple salary PDF report."""
+    buffer = BytesIO()
+    pdf = canvas.Canvas(buffer, pagesize=A4)
+
+    font = FONT_PATH
+    bold_font = font.replace(".ttf", "-Bold.ttf")
+    if os.path.exists(font):
+        pdfmetrics.registerFont(TTFont("Arial", font))
+        if os.path.exists(bold_font):
+            pdfmetrics.registerFont(TTFont("Arial-Bold", bold_font))
+        font_name = "Arial"
+        bold_name = "Arial-Bold" if os.path.exists(bold_font) else "Arial"
+    else:
+        font_name = "Helvetica"
+        bold_name = "Helvetica-Bold"
+
+    y = 800
+    pdf.setFont(bold_name, 16)
+    pdf.drawString(40, y, f"\uD83D\uDCB0 SALARY REPORT - {month}")
+    y -= 24
+
+    pdf.setFont(bold_name, 12)
+    pdf.drawString(50, y, "Name | Shifts | Total ₽ | Final ₽")
+    y -= 18
+    pdf.setFont(font_name, 12)
+
+    for r in rows:
+        line = f"{r.name} | {r.shifts_total} | {r.salary_total:.2f} | {r.final_amount:.2f}"
+        pdf.drawString(50, y, line)
+        y -= 15
+        if y < 60:
+            pdf.showPage()
+            y = 800
+            pdf.setFont(font_name, 12)
+
+    pdf.showPage()
+    pdf.save()
+    buffer.seek(0)
+    return buffer.getvalue()


### PR DESCRIPTION
## Summary
- add PDF generation util for salary reports
- expose `/api/salary/report` endpoint returning generated PDF

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686041c306348329bad8186051da3baa