### PR TITLE
Fix Request argument in fallback routes

### DIFF
--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -144,6 +144,8 @@ class FastAPI:
                         kwargs['path'] = path.lstrip('/')
                 if not match:
                     continue
+                if 'request' in inspect.signature(fn).parameters:
+                    kwargs['request'] = Request()
                 result = fn(**kwargs)
                 if inspect.iscoroutine(result):
                     result = await result


### PR DESCRIPTION
## Summary
- pass a dummy `Request` instance to handlers when needed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686597b9e01c832984e34d1f158978c3