### PR TITLE
Replace model_dump with dict in services

### DIFF
--- a/app/services/advance_requests.py
+++ b/app/services/advance_requests.py
@@ -34,7 +34,7 @@ def load_requests_dataclass() -> List[Payout]:
 
 def save_requests_dataclass(requests: List[Payout]) -> None:
     for r in requests:
-        _repo.update(r.id, r.model_dump(exclude_none=True))
+        _repo.update(r.id, r.dict(exclude_none=True))
 
 
 def log_new_request(

--- a/app/services/incentive_service.py
+++ b/app/services/incentive_service.py
@@ -19,11 +19,11 @@ class IncentiveService:
         return [Incentive(**r) for r in rows]
 
     async def create_incentive(self, data: IncentiveCreate) -> Incentive:
-        created = self._repo.create(data.model_dump())
+        created = self._repo.create(data.dict())
         return Incentive(**created)
 
     async def update_incentive(self, item_id: str, data: IncentiveUpdate) -> Optional[Incentive]:
-        updated = self._repo.update(item_id, data.model_dump(exclude_none=True))
+        updated = self._repo.update(item_id, data.dict(exclude_none=True))
         return Incentive(**updated) if updated else None
 
     async def delete_incentive(self, item_id: str) -> bool:

--- a/app/services/payout_service.py
+++ b/app/services/payout_service.py
@@ -78,7 +78,7 @@ class PayoutService:
         if update.status is not None:
             return await self.update_status(payout_id, update.status)
         updated = self._repo.update(
-            payout_id, update.model_dump(
+            payout_id, update.dict(
                 exclude_none=True))
         if updated:
             logger.info(

--- a/app/services/vacation_service.py
+++ b/app/services/vacation_service.py
@@ -20,7 +20,7 @@ class VacationService:
 
     async def create_vacation(self, data: VacationCreate) -> Vacation:
         self._validate_dates(data.start_date, data.end_date)
-        created = self._repo.create(data.model_dump())
+        created = self._repo.create(data.dict())
         return Vacation(**created)
 
     async def update_vacation(
@@ -36,7 +36,7 @@ class VacationService:
         start = data.start_date or existing.get("start_date")
         end = data.end_date or existing.get("end_date")
         self._validate_dates(start, end)
-        updated = self._repo.update(vac_id, data.model_dump(exclude_none=True))
+        updated = self._repo.update(vac_id, data.dict(exclude_none=True))
         return Vacation(**updated) if updated else None
 
     async def delete_vacation(self, vac_id: str) -> None:

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -23,6 +23,10 @@ class BaseModel:
             data = {k: v for k, v in data.items() if v is not None}
         return data
 
+    def dict(self, *, exclude_none=False):
+        """Alias of ``model_dump`` for compatibility with real pydantic."""
+        return self.model_dump(exclude_none=exclude_none)
+
 
 def Field(default=None, **kwargs):
     return default


### PR DESCRIPTION
## Summary
- add `.dict()` alias in minimal BaseModel
- use `.dict()` when saving Pydantic models in services

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866a2b7fff88329950ff9b437806366