### PR TITLE
Add note to payout requests

### DIFF
--- a/admin_frontend/src/pages/Payouts.jsx
+++ b/admin_frontend/src/pages/Payouts.jsx
@@ -83,6 +83,8 @@ export default function Payouts() {
     status: 'Ожидает',
     sync_to_bot: false,
     notify_user: true,
+    note: '',
+    show_note_in_bot: false,
   };
 
   const [payouts, setPayouts] = useState([]);
@@ -188,7 +190,12 @@ export default function Payouts() {
   }
 
   function openEdit(p) {
-    setForm({ ...p, notify_user: true });
+    setForm({
+      ...p,
+      notify_user: true,
+      note: p.note || '',
+      show_note_in_bot: p.show_note_in_bot || false,
+    });
     setShowEditor(true);
   }
 
@@ -516,6 +523,22 @@ export default function Payouts() {
                 Уведомить сотрудника
               </label>
             )}
+            <textarea
+              className="border p-2 w-full"
+              placeholder="Примечание"
+              value={form.note}
+              onChange={(e) => setForm({ ...form, note: e.target.value })}
+            />
+            <label className="flex items-center gap-1 text-sm">
+              <input
+                type="checkbox"
+                checked={form.show_note_in_bot}
+                onChange={(e) =>
+                  setForm({ ...form, show_note_in_bot: e.target.checked })
+                }
+              />
+              Показывать примечание в боте
+            </label>
             <label className="flex items-center gap-1 text-sm">
               <input
                 type="checkbox"

--- a/advance_requests.example.json
+++ b/advance_requests.example.json
@@ -9,7 +9,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-04-10 13:19:56",
-    "id": "1"
+    "id": "1",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "462581912",
@@ -21,7 +23,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-04-10 13:30:58",
-    "id": "3"
+    "id": "3",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "462581912",
@@ -33,7 +37,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-04-10 13:31:20",
-    "id": "4"
+    "id": "4",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5111123471",
@@ -45,7 +51,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-04-10 13:46:50",
-    "id": "5"
+    "id": "5",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -57,7 +65,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-04-10 13:52:28",
-    "id": "6"
+    "id": "6",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -69,7 +79,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-04-10 13:53:24",
-    "id": "7"
+    "id": "7",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5247714073",
@@ -81,7 +93,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-04-10 14:36:45",
-    "id": "8"
+    "id": "8",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -93,7 +107,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-04-10 15:25:16",
-    "id": "9"
+    "id": "9",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -105,7 +121,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-04-10 15:37:48",
-    "id": "11"
+    "id": "11",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1586122212",
@@ -117,7 +135,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-04-10 19:20:16",
-    "id": "10"
+    "id": "10",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -129,7 +149,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-04-12 11:38:50",
-    "id": "12"
+    "id": "12",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "432793033",
@@ -141,7 +163,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-04-12 11:47:46",
-    "id": "13"
+    "id": "13",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -153,7 +177,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-13 17:18:59",
-    "id": "14"
+    "id": "14",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -165,7 +191,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-16 11:30:24",
-    "id": "15"
+    "id": "15",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -177,7 +205,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-18 17:36:12",
-    "id": "16"
+    "id": "16",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -189,7 +219,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-20 18:40:35",
-    "id": "17"
+    "id": "17",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -201,7 +233,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-21 10:33:12",
-    "id": "18"
+    "id": "18",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "948256529",
@@ -213,7 +247,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-23 17:50:10",
-    "id": "19"
+    "id": "19",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -225,7 +261,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-23 17:53:01",
-    "id": "20"
+    "id": "20",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5247714073",
@@ -237,7 +275,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-24 08:02:57",
-    "id": "21"
+    "id": "21",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -249,7 +289,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-24 09:41:06",
-    "id": "22"
+    "id": "22",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -261,7 +303,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-24 12:55:44",
-    "id": "23"
+    "id": "23",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5111123471",
@@ -273,7 +317,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-25 10:46:58",
-    "id": "24"
+    "id": "24",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -285,7 +331,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-25 12:12:32",
-    "id": "25"
+    "id": "25",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "501393726",
@@ -297,7 +345,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-25 12:17:42",
-    "id": "26"
+    "id": "26",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "831200791",
@@ -309,7 +359,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-25 13:56:19",
-    "id": "27"
+    "id": "27",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1765220057",
@@ -321,7 +373,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-25 15:59:27",
-    "id": "28"
+    "id": "28",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "462581912",
@@ -333,7 +387,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-25 17:57:35",
-    "id": "29"
+    "id": "29",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -345,7 +401,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-26 11:04:23",
-    "id": "30"
+    "id": "30",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1565339213",
@@ -357,7 +415,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-26 19:58:17",
-    "id": "31"
+    "id": "31",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -369,7 +429,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-04-28 17:04:10",
-    "id": "32"
+    "id": "32",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -381,7 +443,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-01 22:45:47",
-    "id": "33"
+    "id": "33",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -393,7 +457,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-02 10:42:38",
-    "id": "34"
+    "id": "34",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -405,7 +471,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-02 10:47:37",
-    "id": "35"
+    "id": "35",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -417,7 +485,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-04 16:34:23",
-    "id": "36"
+    "id": "36",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -429,7 +499,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-06 13:35:10",
-    "id": "37"
+    "id": "37",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -441,7 +513,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-06 17:35:11",
-    "id": "38"
+    "id": "38",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "501393726",
@@ -453,7 +527,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-08 12:00:30",
-    "id": "39"
+    "id": "39",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -465,7 +541,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-08 15:14:04",
-    "id": "40"
+    "id": "40",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -477,7 +555,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-09 13:24:59",
-    "id": "41"
+    "id": "41",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "831200791",
@@ -489,7 +569,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-09 17:46:31",
-    "id": "42"
+    "id": "42",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5247714073",
@@ -501,7 +583,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-09 17:55:42",
-    "id": "43"
+    "id": "43",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1765220057",
@@ -513,7 +597,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-09 18:57:45",
-    "id": "44"
+    "id": "44",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5111123471",
@@ -525,7 +611,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-09 20:55:39",
-    "id": "45"
+    "id": "45",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5111123471",
@@ -537,7 +625,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-09 20:57:17",
-    "id": "46"
+    "id": "46",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "948256529",
@@ -549,7 +639,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-09 22:16:31",
-    "id": "47"
+    "id": "47",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1565339213",
@@ -561,7 +653,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-10 10:16:38",
-    "id": "48"
+    "id": "48",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -573,7 +667,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-10 11:53:17",
-    "id": "49"
+    "id": "49",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -585,7 +681,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-10 16:57:44",
-    "id": "50"
+    "id": "50",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "432793033",
@@ -597,7 +695,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-10 18:59:31",
-    "id": "51"
+    "id": "51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -609,7 +709,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-14 19:24:27",
-    "id": "52"
+    "id": "52",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -621,7 +723,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-15 11:20:25",
-    "id": "53"
+    "id": "53",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -633,7 +737,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-15 12:50:32",
-    "id": "54"
+    "id": "54",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "462581912",
@@ -645,7 +751,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-15 17:48:47",
-    "id": "55"
+    "id": "55",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -657,7 +765,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-16 21:21:58",
-    "id": "56"
+    "id": "56",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -669,7 +779,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-18 18:05:10",
-    "id": "57"
+    "id": "57",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -681,7 +793,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-19 23:47:30",
-    "id": "58"
+    "id": "58",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "501393726",
@@ -693,7 +807,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-20 11:22:25",
-    "id": "59"
+    "id": "59",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1037475044",
@@ -705,7 +821,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-20 18:31:27",
-    "id": "60"
+    "id": "60",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -717,7 +835,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-22 15:25:05",
-    "id": "61"
+    "id": "61",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -729,7 +849,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-23 09:42:24",
-    "id": "62"
+    "id": "62",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "948256529",
@@ -741,7 +863,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-23 12:09:30",
-    "id": "63"
+    "id": "63",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5247714073",
@@ -753,7 +877,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-23 13:57:09",
-    "id": "64"
+    "id": "64",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1565339213",
@@ -765,7 +891,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-24 11:57:50",
-    "id": "65"
+    "id": "65",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -777,7 +905,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-24 13:23:11",
-    "id": "66"
+    "id": "66",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -789,7 +919,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-25 09:35:49",
-    "id": "67"
+    "id": "67",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -801,7 +933,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-25 10:59:30",
-    "id": "68"
+    "id": "68",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1765220057",
@@ -813,7 +947,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-25 16:17:26",
-    "id": "69"
+    "id": "69",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -825,7 +961,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-26 15:08:57",
-    "id": "70"
+    "id": "70",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -837,7 +975,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-27 17:45:14",
-    "id": "71"
+    "id": "71",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -849,7 +989,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-28 14:14:11",
-    "id": "72"
+    "id": "72",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -861,7 +1003,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-29 20:33:36",
-    "id": "73"
+    "id": "73",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5111123471",
@@ -873,7 +1017,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-30 10:59:58",
-    "id": "74"
+    "id": "74",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -885,7 +1031,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-05-30 11:37:26",
-    "id": "75"
+    "id": "75",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5247714073",
@@ -897,7 +1045,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-05-30 11:49:30",
-    "id": "76"
+    "id": "76",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -909,7 +1059,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-01 08:20:02",
-    "id": "77"
+    "id": "77",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -921,7 +1073,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-01 13:06:00",
-    "id": "78"
+    "id": "78",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -933,7 +1087,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-02 11:54:08",
-    "id": "79"
+    "id": "79",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -945,7 +1101,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-02 18:50:34",
-    "id": "80"
+    "id": "80",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -957,7 +1115,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-03 15:15:01",
-    "id": "81"
+    "id": "81",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -969,7 +1129,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-03 15:16:17",
-    "id": "82"
+    "id": "82",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -981,7 +1143,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-04 12:07:27",
-    "id": "83"
+    "id": "83",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -993,7 +1157,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-04 16:21:19",
-    "id": "84"
+    "id": "84",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1005,7 +1171,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-05 14:34:07",
-    "id": "85"
+    "id": "85",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1565339213",
@@ -1017,7 +1185,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-05 20:35:37",
-    "id": "86"
+    "id": "86",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1029,7 +1199,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-06 11:33:54",
-    "id": "87"
+    "id": "87",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1041,7 +1213,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-06 20:04:46",
-    "id": "88"
+    "id": "88",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1053,7 +1227,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-06 20:05:41",
-    "id": "89"
+    "id": "89",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -1065,7 +1241,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-07 10:21:12",
-    "id": "90"
+    "id": "90",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "948256529",
@@ -1077,7 +1255,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-10 07:10:48",
-    "id": "91"
+    "id": "91",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1765220057",
@@ -1089,7 +1269,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-10 09:53:14",
-    "id": "92"
+    "id": "92",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "831200791",
@@ -1101,7 +1283,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-10 11:17:44",
-    "id": "93"
+    "id": "93",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "831200791",
@@ -1113,7 +1297,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-10 11:26:29",
-    "id": "94"
+    "id": "94",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "501393726",
@@ -1125,7 +1311,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-10 11:58:25",
-    "id": "95"
+    "id": "95",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1137,7 +1325,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-10 12:00:39",
-    "id": "96"
+    "id": "96",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1149,7 +1339,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-10 14:12:53",
-    "id": "97"
+    "id": "97",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5111123471",
@@ -1161,7 +1353,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-10 18:40:14",
-    "id": "98"
+    "id": "98",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "432793033",
@@ -1173,7 +1367,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "timestamp": "2025-06-11 08:06:08",
-    "id": "99"
+    "id": "99",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "000",
@@ -1185,7 +1381,9 @@
     "payout_type": "ЗП",
     "status": "Одобрено",
     "timestamp": "2025-06-11 12:34:12",
-    "id": "100"
+    "id": "100",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -1197,7 +1395,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-11 16:55:54",
-    "id": "101"
+    "id": "101",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1209,7 +1409,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-12 10:04:39",
-    "id": "102"
+    "id": "102",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1221,7 +1423,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-12 18:47:24",
-    "id": "103"
+    "id": "103",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1233,7 +1437,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-16 17:35:02",
-    "id": "104"
+    "id": "104",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1245,7 +1451,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-16 20:50:05",
-    "id": "105"
+    "id": "105",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1257,7 +1465,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-17 14:26:01",
-    "id": "107"
+    "id": "107",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1269,7 +1479,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-17 19:11:25",
-    "id": "115"
+    "id": "115",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1281,7 +1493,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-18 12:13:52",
-    "id": "111"
+    "id": "111",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "501393726",
@@ -1293,7 +1507,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-19 13:07:47",
-    "id": "113"
+    "id": "113",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -1305,7 +1521,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-19 14:57:01",
-    "id": "114"
+    "id": "114",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1037475044",
@@ -1317,7 +1535,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-19 20:42:55",
-    "id": "116"
+    "id": "116",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1329,7 +1549,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-19 20:43:48",
-    "id": "117"
+    "id": "117",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -1341,7 +1563,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-20 11:38:55",
-    "id": "118"
+    "id": "118",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1353,7 +1577,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-20 14:29:46",
-    "id": "121"
+    "id": "121",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "20456189804",
@@ -1365,7 +1591,9 @@
     "payout_type": "ЗП",
     "status": "Одобрено",
     "timestamp": "2025-06-21 20:04:14",
-    "id": "124"
+    "id": "124",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1565339213",
@@ -1377,7 +1605,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-22 11:35:01",
-    "id": "125"
+    "id": "125",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -1389,7 +1619,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-23 15:50:46",
-    "id": "126"
+    "id": "126",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1401,7 +1633,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-23 16:25:29",
-    "id": "127"
+    "id": "127",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1413,7 +1647,9 @@
     "payout_type": "🏠 Домой",
     "status": "Отклонено",
     "id": "129",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1425,7 +1661,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "id": "130",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "948256529",
@@ -1437,7 +1675,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "id": "131",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -1449,7 +1689,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "id": "132",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1461,7 +1703,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "id": "133",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1586122212",
@@ -1473,7 +1717,9 @@
     "payout_type": "Зарплата",
     "status": "Отклонено",
     "id": "134",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1586122212",
@@ -1485,7 +1731,9 @@
     "payout_type": "Зарплата",
     "status": "Одобрено",
     "id": "135",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1765220057",
@@ -1497,7 +1745,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "id": "136",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "831200791",
@@ -1509,7 +1759,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "id": "137",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "462581912",
@@ -1521,7 +1773,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "id": "138",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1533,7 +1787,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "id": "142",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1545,7 +1801,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "id": "143",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1557,7 +1815,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "id": "144",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1569,7 +1829,9 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "id": "145",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -1581,6 +1843,8 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-27 17:43:10",
-    "id": "146"
+    "id": "146",
+    "note": "",
+    "show_note_in_bot": false
   }
 ]

--- a/advance_requests.json
+++ b/advance_requests.json
@@ -10,7 +10,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-10 13:19:56",
     "id": "1",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "462581912",
@@ -23,7 +25,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-10 13:30:58",
     "id": "3",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "462581912",
@@ -36,7 +40,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-10 13:31:20",
     "id": "4",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5111123471",
@@ -49,7 +55,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-10 13:46:50",
     "id": "5",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -62,7 +70,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-10 13:52:28",
     "id": "6",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -75,7 +85,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-10 13:53:24",
     "id": "7",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5247714073",
@@ -88,7 +100,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-10 14:36:45",
     "id": "8",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -101,7 +115,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-10 15:25:16",
     "id": "9",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -114,7 +130,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-10 15:37:48",
     "id": "11",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1586122212",
@@ -127,7 +145,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-10 19:20:16",
     "id": "10",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -140,7 +160,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-12 11:38:50",
     "id": "12",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "432793033",
@@ -153,7 +175,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-12 11:47:46",
     "id": "13",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -166,7 +190,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-13 17:18:59",
     "id": "14",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -179,7 +205,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-16 11:30:24",
     "id": "15",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -192,7 +220,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-18 17:36:12",
     "id": "16",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -205,7 +235,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-20 18:40:35",
     "id": "17",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -218,7 +250,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-21 10:33:12",
     "id": "18",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "948256529",
@@ -231,7 +265,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-23 17:50:10",
     "id": "19",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -244,7 +280,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-23 17:53:01",
     "id": "20",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5247714073",
@@ -257,7 +295,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-24 08:02:57",
     "id": "21",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -270,7 +310,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-24 09:41:06",
     "id": "22",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -283,7 +325,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-24 12:55:44",
     "id": "23",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5111123471",
@@ -296,7 +340,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-25 10:46:58",
     "id": "24",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -309,7 +355,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-25 12:12:32",
     "id": "25",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "501393726",
@@ -322,7 +370,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-25 12:17:42",
     "id": "26",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "831200791",
@@ -335,7 +385,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-25 13:56:19",
     "id": "27",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1765220057",
@@ -348,7 +400,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-25 15:59:27",
     "id": "28",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "462581912",
@@ -361,7 +415,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-25 17:57:35",
     "id": "29",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -374,7 +430,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-26 11:04:23",
     "id": "30",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1565339213",
@@ -387,7 +445,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-26 19:58:17",
     "id": "31",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -400,7 +460,9 @@
     "status": "Одобрено",
     "timestamp": "2025-04-28 17:04:10",
     "id": "32",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -413,7 +475,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-01 22:45:47",
     "id": "33",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -426,7 +490,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-02 10:42:38",
     "id": "34",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -439,7 +505,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-02 10:47:37",
     "id": "35",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -452,7 +520,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-04 16:34:23",
     "id": "36",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -465,7 +535,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-06 13:35:10",
     "id": "37",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -478,7 +550,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-06 17:35:11",
     "id": "38",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "501393726",
@@ -491,7 +565,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-08 12:00:30",
     "id": "39",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -504,7 +580,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-08 15:14:04",
     "id": "40",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -517,7 +595,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-09 13:24:59",
     "id": "41",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "831200791",
@@ -530,7 +610,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-09 17:46:31",
     "id": "42",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5247714073",
@@ -543,7 +625,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-09 17:55:42",
     "id": "43",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1765220057",
@@ -556,7 +640,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-09 18:57:45",
     "id": "44",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5111123471",
@@ -569,7 +655,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-09 20:55:39",
     "id": "45",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5111123471",
@@ -582,7 +670,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-09 20:57:17",
     "id": "46",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "948256529",
@@ -595,7 +685,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-09 22:16:31",
     "id": "47",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1565339213",
@@ -608,7 +700,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-10 10:16:38",
     "id": "48",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -621,7 +715,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-10 11:53:17",
     "id": "49",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -634,7 +730,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-10 16:57:44",
     "id": "50",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "432793033",
@@ -647,7 +745,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-10 18:59:31",
     "id": "51",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -660,7 +760,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-14 19:24:27",
     "id": "52",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -673,7 +775,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-15 11:20:25",
     "id": "53",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -686,7 +790,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-15 12:50:32",
     "id": "54",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "462581912",
@@ -699,7 +805,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-15 17:48:47",
     "id": "55",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -712,7 +820,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-16 21:21:58",
     "id": "56",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -725,7 +835,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-18 18:05:10",
     "id": "57",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -738,7 +850,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-19 23:47:30",
     "id": "58",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "501393726",
@@ -751,7 +865,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-20 11:22:25",
     "id": "59",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1037475044",
@@ -764,7 +880,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-20 18:31:27",
     "id": "60",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -777,7 +895,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-22 15:25:05",
     "id": "61",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -790,7 +910,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-23 09:42:24",
     "id": "62",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "948256529",
@@ -803,7 +925,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-23 12:09:30",
     "id": "63",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5247714073",
@@ -816,7 +940,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-23 13:57:09",
     "id": "64",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1565339213",
@@ -829,7 +955,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-24 11:57:50",
     "id": "65",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -842,7 +970,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-24 13:23:11",
     "id": "66",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -855,7 +985,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-25 09:35:49",
     "id": "67",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -868,7 +1000,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-25 10:59:30",
     "id": "68",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1765220057",
@@ -881,7 +1015,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-25 16:17:26",
     "id": "69",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -894,7 +1030,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-26 15:08:57",
     "id": "70",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -907,7 +1045,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-27 17:45:14",
     "id": "71",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -920,7 +1060,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-28 14:14:11",
     "id": "72",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -933,7 +1075,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-29 20:33:36",
     "id": "73",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5111123471",
@@ -946,7 +1090,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-30 10:59:58",
     "id": "74",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -959,7 +1105,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-30 11:37:26",
     "id": "75",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5247714073",
@@ -972,7 +1120,9 @@
     "status": "Одобрено",
     "timestamp": "2025-05-30 11:49:30",
     "id": "76",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -985,7 +1135,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-01 08:20:02",
     "id": "77",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -998,7 +1150,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-01 13:06:00",
     "id": "78",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1011,7 +1165,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-02 11:54:08",
     "id": "79",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -1024,7 +1180,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-02 18:50:34",
     "id": "80",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -1037,7 +1195,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-03 15:15:01",
     "id": "81",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1050,7 +1210,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-03 15:16:17",
     "id": "82",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -1063,7 +1225,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-04 12:07:27",
     "id": "83",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1076,7 +1240,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-04 16:21:19",
     "id": "84",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1089,7 +1255,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-05 14:34:07",
     "id": "85",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1565339213",
@@ -1102,7 +1270,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-05 20:35:37",
     "id": "86",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1115,7 +1285,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-06 11:33:54",
     "id": "87",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1128,7 +1300,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-06 20:04:46",
     "id": "88",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1141,7 +1315,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-06 20:05:41",
     "id": "89",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -1154,7 +1330,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-07 10:21:12",
     "id": "90",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "948256529",
@@ -1167,7 +1345,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-10 07:10:48",
     "id": "91",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1765220057",
@@ -1180,7 +1360,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-10 09:53:14",
     "id": "92",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "831200791",
@@ -1193,7 +1375,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-10 11:17:44",
     "id": "93",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "831200791",
@@ -1206,7 +1390,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-10 11:26:29",
     "id": "94",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "501393726",
@@ -1219,7 +1405,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-10 11:58:25",
     "id": "95",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1232,7 +1420,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-10 12:00:39",
     "id": "96",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1245,7 +1435,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-10 14:12:53",
     "id": "97",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "5111123471",
@@ -1258,7 +1450,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-10 18:40:14",
     "id": "98",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "432793033",
@@ -1271,7 +1465,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-11 08:06:08",
     "id": "99",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "000",
@@ -1284,7 +1480,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-11 12:34:12",
     "id": "100",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -1297,7 +1495,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-11 16:55:54",
     "id": "101",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1310,7 +1510,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-12 10:04:39",
     "id": "102",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1323,7 +1525,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-12 18:47:24",
     "id": "103",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1336,7 +1540,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-16 17:35:02",
     "id": "104",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1349,7 +1555,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-16 20:50:05",
     "id": "105",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1362,7 +1570,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-17 14:26:01",
     "id": "107",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1375,7 +1585,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-17 19:11:25",
     "id": "115",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1388,7 +1600,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-18 12:13:52",
     "id": "111",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "501393726",
@@ -1401,7 +1615,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-19 13:07:47",
     "id": "113",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -1414,7 +1630,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-19 14:57:01",
     "id": "114",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1037475044",
@@ -1427,7 +1645,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-19 20:42:55",
     "id": "116",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1440,7 +1660,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-19 20:43:48",
     "id": "117",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1674595510",
@@ -1453,7 +1675,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-20 11:38:55",
     "id": "118",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1466,7 +1690,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-20 14:29:46",
     "id": "121",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "20456189804",
@@ -1479,7 +1705,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-21 20:04:14",
     "id": "124",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1565339213",
@@ -1492,7 +1720,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-22 11:35:01",
     "id": "125",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -1505,7 +1735,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-23 15:50:46",
     "id": "126",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1518,7 +1750,9 @@
     "status": "Одобрено",
     "timestamp": "2025-06-23 16:25:29",
     "id": "127",
-    "full_name": ""
+    "full_name": "",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1531,7 +1765,9 @@
     "status": "Отклонено",
     "id": "129",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1544,7 +1780,9 @@
     "status": "Одобрено",
     "id": "130",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "948256529",
@@ -1557,7 +1795,9 @@
     "status": "Одобрено",
     "id": "131",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1782368094",
@@ -1570,7 +1810,9 @@
     "status": "Одобрено",
     "id": "132",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1583,7 +1825,9 @@
     "status": "Одобрено",
     "id": "133",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1586122212",
@@ -1596,7 +1840,9 @@
     "status": "Отклонено",
     "id": "134",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1586122212",
@@ -1609,7 +1855,9 @@
     "status": "Одобрено",
     "id": "135",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "1765220057",
@@ -1622,7 +1870,9 @@
     "status": "Одобрено",
     "id": "136",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "831200791",
@@ -1635,7 +1885,9 @@
     "status": "Одобрено",
     "id": "137",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "462581912",
@@ -1648,7 +1900,9 @@
     "status": "Одобрено",
     "id": "138",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1661,7 +1915,9 @@
     "status": "Одобрено",
     "id": "142",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "805091546",
@@ -1674,7 +1930,9 @@
     "status": "Одобрено",
     "id": "143",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "2045618984",
@@ -1687,7 +1945,9 @@
     "status": "Одобрено",
     "id": "144",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "6270418859",
@@ -1700,7 +1960,9 @@
     "status": "Одобрено",
     "id": "145",
     "full_name": "",
-    "timestamp": "2025-06-27 11:24:51"
+    "timestamp": "2025-06-27 11:24:51",
+    "note": "",
+    "show_note_in_bot": false
   },
   {
     "user_id": "7385498306",
@@ -1712,6 +1974,8 @@
     "payout_type": "Аванс",
     "status": "Одобрено",
     "timestamp": "2025-06-27 17:43:10",
-    "id": "146"
+    "id": "146",
+    "note": "",
+    "show_note_in_bot": false
   }
 ]

--- a/app/schemas/payout.py
+++ b/app/schemas/payout.py
@@ -14,6 +14,8 @@ class Payout(BaseModel):
     payout_type: str
     status: str
     timestamp: Optional[datetime] = None
+    note: Optional[str] = None
+    show_note_in_bot: bool = False
 
 
 class PayoutCreate(BaseModel):
@@ -25,6 +27,8 @@ class PayoutCreate(BaseModel):
     method: str
     payout_type: str
     sync_to_bot: bool = False
+    note: Optional[str] = None
+    show_note_in_bot: bool = False
 
 
 class PayoutUpdate(BaseModel):
@@ -37,6 +41,8 @@ class PayoutUpdate(BaseModel):
     payout_type: Optional[str] = None
     status: Optional[str] = None
     notify_user: Optional[bool] = None
+    note: Optional[str] = None
+    show_note_in_bot: Optional[bool] = None
 
 
 class PayoutControlItem(BaseModel):

--- a/app/services/payout_service.py
+++ b/app/services/payout_service.py
@@ -56,6 +56,8 @@ class PayoutService:
             "payout_type": data.payout_type,
             "status": "Ожидает",
             "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "note": data.note or "",
+            "show_note_in_bot": data.show_note_in_bot,
         }
         created = self._repo.create(payout_dict)
         logger.info(

--- a/app/services/telegram_service.py
+++ b/app/services/telegram_service.py
@@ -181,6 +181,8 @@ class TelegramService:
             f"💳 Метод: {payout['method']}\n"
             f"📂 Тип: {payout['payout_type']}"
         )
+        if payout.get("note") and payout.get("show_note_in_bot"):
+            text += f"\n\n📝 {payout['note']}"
         markup = InlineKeyboardMarkup(
             [
                 [InlineKeyboardButton("✅ Разрешить", callback_data=f"allow_payout_{payout['user_id']}")],


### PR DESCRIPTION
## Summary
- extend payout schemas with `note` and `show_note_in_bot`
- store the fields when creating payouts
- show payout note in Telegram only if required
- support note editing in admin UI
- update example data for schema tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68691b31a220832983c21ae401bafa1a