### PR TITLE
Update payout approval logic

### DIFF
--- a/app/handlers/admin/payout_actions.py
+++ b/app/handlers/admin/payout_actions.py
@@ -47,32 +47,33 @@ PENDING_STATUSES = {"Ожидает", "В ожидании"}
 async def allow_payout(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
     await query.answer()
-    user_id = query.data.split("_")[-1]
-    log(f"✅ [allow_payout] Одобрение выплаты для user_id: {user_id}")
+    payout_id = query.data.split("_")[-1]
+    log(f"✅ [allow_payout] Одобрение выплаты для payout_id: {payout_id}")
 
     payout_requests = load_advance_requests()
     request_to_approve = next(
         (
             r
             for r in payout_requests
-            if r["user_id"] == user_id and r.get("status") in PENDING_STATUSES
+            if str(r.get("id")) == str(payout_id) and r.get("status") in PENDING_STATUSES
         ),
         None,
     )
     if not request_to_approve:
-        log(f"⚠️ [allow_payout] Запрос для user_id {user_id} не найден")
+        log(f"⚠️ [allow_payout] Запрос {payout_id} не найден")
         audit_logger.warning(
-            f"Не найден запрос на одобрение для user_id {user_id}"
+            f"Не найден запрос на одобрение {payout_id}"
         )
         await query.edit_message_text("❌ Нет активного запроса для одобрения.")
         return
 
+    user_id = request_to_approve["user_id"]
     log(
         f"📋 [allow_payout] Найден запрос {request_to_approve['id']} для user_id {user_id}"
     )
 
     try:
-        updated = update_request_status(user_id, "approved")
+        updated = update_request_status(payout_id, "approved")
     except Exception as e:
         log(f"❌ Ошибка обновления статуса выплаты: {e}")
         updated = False
@@ -154,32 +155,34 @@ async def allow_payout(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 async def deny_payout(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
     await query.answer()
-    user_id = query.data.split("_")[-1]
-    log(f"❌ [deny_payout] Отклонение выплаты для user_id: {user_id}")
+    payout_id = query.data.split("_")[-1]
+    log(f"❌ [deny_payout] Отклонение выплаты для payout_id: {payout_id}")
 
     payout_requests = load_advance_requests()
     request_to_deny = next(
         (
             r
             for r in payout_requests
-            if r["user_id"] == user_id and r.get("status") in PENDING_STATUSES
+            if str(r.get("id")) == str(payout_id) and r.get("status") in PENDING_STATUSES
         ),
         None,
     )
     if not request_to_deny:
-        log(f"⚠️ [deny_payout] Запрос для user_id {user_id} не найден")
+        log(f"⚠️ [deny_payout] Запрос {payout_id} не найден")
         audit_logger.warning(
-            f"Не найден запрос на отклонение для user_id {user_id}"
+            f"Не найден запрос на отклонение {payout_id}"
         )
         await query.edit_message_text("❌ Нет активного запроса для отклонения.")
         return
 
     log(
-        f"📋 [deny_payout] Найден запрос {request_to_deny['id']} для user_id {user_id}"
+        f"📋 [deny_payout] Найден запрос {request_to_deny['id']} для user_id {request_to_deny['user_id']}"
     )
 
+    user_id = request_to_deny["user_id"]
+
     try:
-        updated = update_request_status(user_id, "rejected")
+        updated = update_request_status(payout_id, "rejected")
     except Exception as e:
         log(f"❌ Ошибка обновления статуса выплаты: {e}")
         updated = False
@@ -257,7 +260,7 @@ async def reset_payout_request(update: Update, context: ContextTypes.DEFAULT_TYP
     if pending_requests:
         for req in pending_requests:
             req["status"] = "Отменено"
-            update_request_status(req["user_id"], "cancelled")
+            update_request_status(req["id"], "cancelled")
             reset_details.append(
                 f"👤 {req['name']} (ID: {req['user_id']})\n"
                 f"Сумма: {req['amount']} ₽\n"

--- a/app/handlers/user/payout.py
+++ b/app/handlers/user/payout.py
@@ -207,7 +207,7 @@ async def handle_card_confirmation(
         save_users(users)
     try:
         log(f"DEBUG [handle_card_confirmation] Логируем запрос для {user_id}")
-        log_new_request(
+        record = log_new_request(
             user_id,
             name,
             phone,
@@ -215,6 +215,7 @@ async def handle_card_confirmation(
             amount,
             method,
             payout_type)
+        payout_id = record.get("id")
     except Exception as e:
         log(f"❌ [handle_card_confirmation] Ошибка записи запроса: {e}")
         await query.edit_message_text(
@@ -241,8 +242,8 @@ async def handle_card_confirmation(
     )
     admin_buttons = InlineKeyboardMarkup(
         [
-            [InlineKeyboardButton("✅ Разрешить", callback_data=f"allow_payout_{user_id}")],
-            [InlineKeyboardButton("❌ Отклонить", callback_data=f"deny_payout_{user_id}")],
+            [InlineKeyboardButton("✅ Разрешить", callback_data=f"allow_payout_{payout_id}")],
+            [InlineKeyboardButton("❌ Отклонить", callback_data=f"deny_payout_{payout_id}")],
         ]
     )
     try:
@@ -311,16 +312,17 @@ async def confirm_payout_user(update: Update,
         f"Способ выплаты: {'Переводом на карту' if payout_method == '💳 На карту' else payout_method}\n\n"
         f"Пользователь: {name}\n"
     )
-    keyboard = InlineKeyboardMarkup(
-        [
-            [InlineKeyboardButton("✅ Разрешить", callback_data=f"allow_payout_{user_id}")],
-            [InlineKeyboardButton("❌ Запретить", callback_data=f"deny_payout_{user_id}")],
-        ]
-    )
     try:
         log(f"DEBUG [confirm_payout_user] Логируем запрос для {user_id}")
-        log_new_request(
+        record = log_new_request(
             user_id, name, phone, bank, amount, payout_method, payout_type
+        )
+        payout_id = record.get("id")
+        keyboard = InlineKeyboardMarkup(
+            [
+                [InlineKeyboardButton("✅ Разрешить", callback_data=f"allow_payout_{payout_id}")],
+                [InlineKeyboardButton("❌ Запретить", callback_data=f"deny_payout_{payout_id}")],
+            ]
         )
     except Exception as e:
         log(f"❌ [confirm_payout_user] Ошибка записи запроса: {e}")

--- a/app/services/telegram_service.py
+++ b/app/services/telegram_service.py
@@ -185,8 +185,8 @@ class TelegramService:
             text += f"\n\n📝 {payout['note']}"
         markup = InlineKeyboardMarkup(
             [
-                [InlineKeyboardButton("✅ Разрешить", callback_data=f"allow_payout_{payout['user_id']}")],
-                [InlineKeyboardButton("❌ Отклонить", callback_data=f"deny_payout_{payout['user_id']}")],
+                [InlineKeyboardButton("✅ Разрешить", callback_data=f"allow_payout_{payout['id']}")],
+                [InlineKeyboardButton("❌ Отклонить", callback_data=f"deny_payout_{payout['id']}")],
             ]
         )
         if not ADMIN_CHAT_ID:

--- a/tests/test_advance_requests.py
+++ b/tests/test_advance_requests.py
@@ -1,0 +1,49 @@
+import types
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import app.services.advance_requests as ar
+
+class DummyRepo:
+    def __init__(self):
+        self.data = []
+        self.counter = 0
+    def list(self, employee_id=None, *args, **kwargs):
+        if employee_id is None:
+            return list(self.data)
+        return [d for d in self.data if str(d["user_id"]) == str(employee_id)]
+    def load_all(self):
+        return list(self.data)
+    def create(self, payload):
+        self.counter += 1
+        rec = dict(payload)
+        rec["id"] = str(self.counter)
+        self.data.append(rec)
+        return rec
+    def update(self, payout_id, updates):
+        for item in self.data:
+            if str(item["id"]) == str(payout_id):
+                item.update(updates)
+                return item
+        return None
+
+def setup_repo(monkeypatch):
+    repo = DummyRepo()
+    monkeypatch.setattr(ar, "_repo", repo)
+    return repo
+
+def test_multiple_pending_requests_individual_update(monkeypatch):
+    repo = setup_repo(monkeypatch)
+    r1 = ar.log_new_request("u1", "A", "p", "b", 100, "m", "type")
+    r2 = ar.log_new_request("u1", "A", "p", "b", 200, "m", "type")
+    assert r1["id"] != r2["id"]
+    assert repo.data[0]["status"] == "Ожидает"
+    assert repo.data[1]["status"] == "Ожидает"
+    ar.update_request_status(r1["id"], "approved")
+    assert repo.data[0]["status"] == "Одобрено"
+    assert repo.data[1]["status"] == "Ожидает"
+    ar.update_request_status(r2["id"], "rejected")
+    assert repo.data[1]["status"] == "Отклонено"


### PR DESCRIPTION
## Summary
- return created payout record from `log_new_request`
- reference payout IDs when confirming or denying payouts
- update services to update requests by payout ID
- adjust admin handlers for new callback format
- extend tests for per-request approvals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693752351483299c6b4006340c9f99