### PR TITLE
Fix payout ID matching by normalizing int values

### DIFF
--- a/app/handlers/admin/payout_actions.py
+++ b/app/handlers/admin/payout_actions.py
@@ -31,6 +31,8 @@ from ...services.advance_requests import (
 from ...utils.logger import log
 from ...utils import is_valid_user_id
 
+logger = logging.getLogger(__name__)
+
 
 audit_logger = logging.getLogger("payout_actions")
 if not audit_logger.handlers:
@@ -47,24 +49,22 @@ PENDING_STATUSES = {"Ожидает", "В ожидании"}
 async def allow_payout(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
     await query.answer()
-    payout_id = query.data.split("_")[-1]
+    payout_id = int(query.data.split("_")[-1])
     log(f"✅ [allow_payout] Одобрение выплаты для payout_id: {payout_id}")
 
-    payout_requests = load_advance_requests()
-    request_to_approve = next(
-        (
-            r
-            for r in payout_requests
-            if str(r.get("id")) == str(payout_id) and r.get("status") in PENDING_STATUSES
-        ),
-        None,
-    )
+    payouts = load_advance_requests()
+    logger.debug(f"[allow_payout] Все ID в базе: {[p['id'] for p in payouts]}")
+
+    request_to_approve = next((p for p in payouts if p["id"] == payout_id), None)
     if not request_to_approve:
-        log(f"⚠️ [allow_payout] Запрос {payout_id} не найден")
-        audit_logger.warning(
-            f"Не найден запрос на одобрение {payout_id}"
-        )
+        logger.warning(f"Не найден запрос на одобрение {payout_id}")
         await query.edit_message_text("❌ Нет активного запроса для одобрения.")
+        return
+    if request_to_approve.get("status") not in PENDING_STATUSES:
+        log(
+            f"⚠️ [allow_payout] Запрос {payout_id} не в ожидающем статусе"
+        )
+        await query.edit_message_text("❌ Запрос уже обработан.")
         return
 
     user_id = request_to_approve["user_id"]

--- a/app/services/advance_requests.py
+++ b/app/services/advance_requests.py
@@ -23,6 +23,12 @@ def load_advance_requests() -> List[Dict[str, Any]]:
     path = _repo._file
     log(f"📂 Загрузка заявок из: {path}")
     data = _repo.load_all()
+    for payout in data:
+        if "id" in payout:
+            try:
+                payout["id"] = int(payout["id"])
+            except (TypeError, ValueError):
+                pass
     log(f"✅ Загружено заявок: {len(data)}")
     return data
 


### PR DESCRIPTION
## Summary
- ensure IDs from advance_requests are integers
- log all loaded IDs when approving payouts
- handle missing payout ID with warning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694d989da08329885e514c138098f1