### PR TITLE
Fix indentation in advance requests module

### DIFF
--- a/app/services/advance_requests.py
+++ b/app/services/advance_requests.py
@@ -26,7 +26,6 @@ def load_advance_requests() -> List[Dict[str, Any]]:
     path = _repo._file
     log(f"📂 Загрузка заявок из: {path}")
     data = _repo.load_all()
-codex/провести-техническую-диагностику-проекта
     log(f"✅ Загружено заявок: {len(data)}")
     return data
 


### PR DESCRIPTION
## Summary
- remove stray line from `advance_requests.py` causing indentation error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686969ce68cc83298a0f2baac18a0cfc